### PR TITLE
Removed EOFError

### DIFF
--- a/lib/arduino_firmata/arduino.rb
+++ b/lib/arduino_firmata/arduino.rb
@@ -175,9 +175,9 @@ module ArduinoFirmata
     def read
       return if status == Status::CLOSE
       if nonblock_io
-        @serial.read_nonblock @read_byte_size rescue EOFError
+        @serial.read_nonblock @read_byte_size rescue ''
       else
-        @serial.read @read_byte_size rescue EOFError
+        @serial.read @read_byte_size rescue ''
       end
     end
 


### PR DESCRIPTION
When the data can't be read an error is raised and an `EOFError` is returned as value. When i generate sysex on my arduino i get this then:

``` ruby
sysex 54 ("2\x000\x006\x004\x00")
sysex 69 ("OFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFError62\x000\x006\x004\x00")
sysex 54 ("EOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFErrorEOFError2\x000\x006\x004\x00")
sysex 54 ("2\x000\x006\x004\x00")
```

(It seems also to generate a strange sysex (sysex 69))

In order to get the correct result i had to remove the `EOFError`. Im not sure what it is used for. Because it is simply converted into a string. But really i want to wait until the rest of data is available. So when i remove the `EOFError` the sysex works properly:

``` ruby
sysex 54 ("2\x000\x006\x004\x00")
sysex 54 ("2\x000\x006\x004\x00")
sysex 54 ("2\x000\x006\x004\x00")
sysex 54 ("2\x000\x006\x004\x00")
sysex 54 ("2\x000\x006\x004\x00")
sysex 54 ("2\x000\x006\x004\x00")
```
