### PR TITLE
Fix problem where write would block (with eventmachine)

### DIFF
--- a/lib/arduino_firmata/arduino.rb
+++ b/lib/arduino_firmata/arduino.rb
@@ -166,7 +166,12 @@ module ArduinoFirmata
     def write(cmd)
       return if status == Status::CLOSE
       if nonblock_io
-        @serial.write_nonblock cmd.chr
+        begin
+          @serial.write_nonblock cmd.chr
+        rescue Errno::EAGAIN
+          sleep 0.1
+          retry
+        end
       else
         @serial.write cmd.chr
       end


### PR DESCRIPTION
When i try to connect to the arduino on linux i get a:

``` ruby
lib/arduino_firmata/arduino.rb:169: in `write_nonblock':
  Resource temporarily unavailable - write would block (Errno::EAGAIN)
```

This fix retries sending with a little delay, until the device is ready for sending.
